### PR TITLE
Use pkg-config for GDAL include path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS += `pkg-config --libs proj`
 LDFLAGS += `pkg-config --libs gdal`
 
 ifneq ($(OS),Windows_NT)
-	CFLAGS += -fPIC -I/usr/include/gdal
+	CFLAGS += -fPIC `pkg-config --cflags gdal`
 
 	ifeq ($(shell uname),Darwin)
 		LDFLAGS += -std=c++11 -dynamiclib -undefined dynamic_lookup


### PR DESCRIPTION
## Summary
- Replaced hardcoded `-I/usr/include/gdal` with `` `pkg-config --cflags gdal` `` in the Makefile
- The hardcoded path only works on Linux with GDAL installed via `apt`. On macOS with Homebrew, the headers are at a different location (e.g. `/opt/homebrew/Cellar/gdal/x.x.x/include`)
- `pkg-config` resolves the correct include path on any platform

## Test plan
- [x] Verified compilation on macOS with Homebrew-installed GDAL
- [ ] Verify compilation on Linux with apt-installed GDAL (should resolve to the same `/usr/include/gdal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)