### PR TITLE
Generate static builds for NIFs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,8 @@
+# Used by "mix format"
+[
+  inputs: [
+    "{mix,.formatter}.exs",
+    "{config,lib,test}/**/*.{ex,exs}",
+    "mix/**/*.{ex,exs}"
+  ]
+]

--- a/.github/workflows/precompile.yaml
+++ b/.github/workflows/precompile.yaml
@@ -1,0 +1,179 @@
+name: Precompile NIFs
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  PROJ_VERSION: "9.4.1"
+  GDAL_VERSION: "3.9.3"
+  SQLITE_VERSION: "3470200"
+
+jobs:
+  linux:
+    name: NIF (${{ matrix.job.nif-version }}) - ${{ matrix.job.target }}
+    runs-on: ${{ matrix.job.os }}
+    env:
+      MIX_ENV: prod
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - {
+              target: x86_64-linux-gnu,
+              os: ubuntu-22.04,
+              otp: "25.x",
+              elixir: "1.17.x",
+              nif-version: "2.16",
+            }
+          - {
+              target: x86_64-linux-gnu,
+              os: ubuntu-22.04,
+              otp: "27.x",
+              elixir: "1.17.x",
+              nif-version: "2.17",
+            }
+          - {
+              target: aarch64-linux-gnu,
+              os: ubuntu-22.04-arm,
+              otp: "25.x",
+              elixir: "1.17.x",
+              nif-version: "2.16",
+            }
+          - {
+              target: aarch64-linux-gnu,
+              os: ubuntu-22.04-arm,
+              otp: "27.x",
+              elixir: "1.17.x",
+              nif-version: "2.17",
+            }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # We use setup-beam because it works on arm as well and mise does not
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.job.otp }}
+          elixir-version: ${{ matrix.job.elixir }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache prebuilt PROJ + GDAL
+        id: cache-libs
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/prebuilt
+          key: libs-${{ matrix.job.os }}-proj-${{ env.PROJ_VERSION }}-gdal-${{ env.GDAL_VERSION }}-sqlite-${{ env.SQLITE_VERSION }}
+
+      - name: Build PROJ + GDAL (static, via Docker)
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: |
+          bash scripts/build_libs.sh
+
+      - name: Install Hex + Rebar
+        run: mix local.hex --force && mix local.rebar --force
+
+      - name: Install deps
+        run: mix deps.get
+
+      - name: Precompile NIF
+        run: |
+          export BUNDLED_LIBS_PREFIX=${{ github.workspace }}/prebuilt
+          export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
+          mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
+          mix elixir_make.precompile
+
+      - uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: cache/*.tar.gz
+
+  macos:
+    name: NIF (${{ matrix.job.nif-version }}) - ${{ matrix.job.target }}
+    runs-on: ${{ matrix.job.os }}
+    env:
+      MIX_ENV: prod
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - {
+              target: aarch64-apple-darwin,
+              os: macos-14,
+              otp: "25.1",
+              elixir: "1.17.0",
+              nif-version: "2.16",
+            }
+          - {
+              target: aarch64-apple-darwin,
+              os: macos-14,
+              otp: "27.0",
+              elixir: "1.17.0",
+              nif-version: "2.17",
+            }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install mise
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+
+      # We need to use the version from the job to ensure nif 2.16 gets built on otp 25
+      - name: Ignore .tool-versions for CI
+        run: rm -f .tool-versions
+
+      # Cache mise installs
+      - name: Cache mise
+        id: mise-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/mise
+          key: mise-${{ runner.os }}-${{ matrix.job.otp }}-${{ matrix.job.elixir }}
+
+      # Install Erlang & Elixir
+      - name: Install Erlang & Elixir via mise
+        env:
+          ELIXIR_VERSION: ${{ matrix.job.elixir }}
+          OTP_VERSION: ${{ matrix.job.otp }}
+        run: |
+          ELIXIR_OTP_VERSION=$(echo $OTP_VERSION | cut -d. -f1)
+          mise use -g erlang@${OTP_VERSION}
+          mise use -g elixir@${ELIXIR_VERSION}-otp-${ELIXIR_OTP_VERSION}
+
+      - name: Cache prebuilt PROJ + GDAL
+        id: cache-libs
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/prebuilt
+          key: libs-${{ matrix.job.os }}-proj-${{ env.PROJ_VERSION }}-gdal-${{ env.GDAL_VERSION }}-sqlite-${{ env.SQLITE_VERSION }}
+
+      - name: Build PROJ + GDAL (static)
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        env:
+          PROJ_VERSION: ${{ env.PROJ_VERSION }}
+          GDAL_VERSION: ${{ env.GDAL_VERSION }}
+        run: |
+          bash scripts/build_libs.sh
+
+      - name: Install Hex + Rebar
+        run: mix local.hex --force && mix local.rebar --force
+
+      - name: Install deps
+        run: mix deps.get
+
+      - name: Precompile NIF
+        run: |
+          export BUNDLED_LIBS_PREFIX=${{ github.workspace }}/prebuilt
+          export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
+          export CXXFLAGS="-std=c++17"
+          mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
+          mix elixir_make.precompile
+
+      - uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: cache/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@
 /deps
 /priv
 /doc
+/prebuilt
+/prebuilt-aarch64
+/cache
 erl_crash.dump
 *.ez

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,70 @@
+FROM debian:bookworm-slim AS builder
+
+ARG PROJ_VERSION=9.4.1
+ARG GDAL_VERSION=3.9.3
+ARG SQLITE_VERSION=3470200
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build pkg-config curl ca-certificates \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+RUN curl -fL "https://www.sqlite.org/2024/sqlite-autoconf-${SQLITE_VERSION}.tar.gz" | tar xz && \
+    cd sqlite-autoconf-${SQLITE_VERSION} && \
+    CFLAGS="-fPIC -O2" ./configure --prefix=/prebuilt --disable-shared --enable-static && \
+    make -j$(nproc) && make install
+
+ENV PATH="/prebuilt/bin:${PATH}"
+
+RUN curl -fL "https://download.osgeo.org/proj/proj-${PROJ_VERSION}.tar.gz" | tar xz && \
+    curl -fL "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz" | tar xz
+
+RUN cmake -S proj-${PROJ_VERSION} -B proj-build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/prebuilt \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DBUILD_APPS=OFF \
+      -DENABLE_TIFF=OFF \
+      -DENABLE_CURL=OFF \
+      "-DSQLITE3_INCLUDE_DIR=/prebuilt/include" \
+      "-DSQLITE3_LIBRARY=/prebuilt/lib/libsqlite3.a"
+
+RUN cmake --build proj-build --parallel && cmake --install proj-build
+
+RUN cmake -S gdal-${GDAL_VERSION} -B gdal-build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/prebuilt \
+      -DCMAKE_PREFIX_PATH=/prebuilt \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DCMAKE_C_FLAGS="-fPIC" \
+      -DCMAKE_CXX_FLAGS="-fPIC" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DBUILD_APPS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DGDAL_USE_CURL=OFF \
+      -DGDAL_USE_EXPAT=OFF \
+      -DGDAL_USE_LIBXML2=OFF \
+      -DGDAL_USE_PNG=OFF \
+      -DGDAL_USE_JPEG=OFF \
+      -DGDAL_USE_TIFF=OFF \
+      -DGDAL_USE_JSONC=OFF \
+      -DGDAL_USE_QHULL=OFF \
+      -DGDAL_USE_OPENJPEG=OFF \
+      -DGDAL_USE_WEBP=OFF \
+      -DGDAL_USE_GEOS=OFF \
+      -DGDAL_OBJECT_LIBRARIES_POSITION_INDEPENDENT_CODE=ON \
+      "-DPROJ_INCLUDE_DIR=/prebuilt/include" \
+      "-DPROJ_LIBRARY=/prebuilt/lib/libproj.a" \
+      "-DSQLITE3_INCLUDE_DIR=/prebuilt/include" \
+      "-DSQLITE3_LIBRARY=/prebuilt/lib/libsqlite3.a"
+
+RUN cmake --build gdal-build --parallel && cmake --install gdal-build
+
+FROM scratch
+COPY --from=builder /prebuilt /

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,56 @@
 MIX = mix
-CFLAGS = -g -O3
+CFLAGS = -g -O3 -std=c++17
+
 
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
-CFLAGS += -I$(ERLANG_PATH) `pkg-config --cflags proj`
-LDFLAGS += `pkg-config --libs proj`
-LDFLAGS += `pkg-config --libs gdal`
+CFLAGS += -I$(ERLANG_PATH)
 
 ifneq ($(OS),Windows_NT)
-	CFLAGS += -fPIC `pkg-config --cflags gdal`
+	CFLAGS += -fPIC
 
 	ifeq ($(shell uname),Darwin)
-		LDFLAGS += -std=c++11 -dynamiclib -undefined dynamic_lookup
+		LDFLAGS += -dynamiclib -undefined dynamic_lookup
+		SYS_LDFLAGS = -lc++ -lm -lz -lsqlite3
+	else
+		SYS_LDFLAGS = -lstdc++ -lm -ldl -lpthread -lz
 	endif
+endif
+
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef BUNDLED_LIBS_PREFIX
+  ifneq ($(wildcard $(MAKEFILE_DIR)prebuilt/lib/libgdal.a),)
+    BUNDLED_LIBS_PREFIX := $(MAKEFILE_DIR)prebuilt
+  endif
+endif
+
+ifdef BUNDLED_LIBS_PREFIX
+	CFLAGS += -I$(BUNDLED_LIBS_PREFIX)/include -I$(BUNDLED_LIBS_PREFIX)/include/gdal
+	STATIC_LIBS = $(BUNDLED_LIBS_PREFIX)/lib/libgdal.a \
+	              $(BUNDLED_LIBS_PREFIX)/lib/libproj.a
+	ifneq ($(shell uname),Darwin)
+		STATIC_LIBS += $(BUNDLED_LIBS_PREFIX)/lib/libsqlite3.a
+	endif
+else
+	CFLAGS  += $(shell pkg-config --cflags proj gdal)
+	LDFLAGS += $(shell pkg-config --libs proj gdal)
 endif
 
 .PHONY: all clean
 
+ifdef BUNDLED_LIBS_PREFIX
+all: priv/reproject.so priv/proj_data/proj.db
+else
 all: priv/reproject.so
+endif
 
 priv/reproject.so: src/reproject.cc
 	mkdir -p priv
-	$(CXX) $(CFLAGS) -shared -o $@ src/reproject.cc $(LDFLAGS)
+	$(CXX) $(CFLAGS) -shared -o $@ src/reproject.cc $(STATIC_LIBS) $(LDFLAGS) $(SYS_LDFLAGS)
+
+priv/proj_data/proj.db:
+	mkdir -p priv/proj_data
+	cp $(BUNDLED_LIBS_PREFIX)/share/proj/proj.db priv/proj_data/
 
 clean:
 	$(MIX) clean

--- a/README.md
+++ b/README.md
@@ -1,47 +1,81 @@
 # reproject
-Reproject a point. This is just a nif that calls into proj4 and gdal
 
-## Setup
-You need proj4 and gdal installed on your system. Install it with
+Reproject a point. NIF bindings to [PROJ](https://proj.org/) (v9) and GDAL for
+coordinate system transformations.
+
+## Installation
+
+Add `reproject` to your dependencies:
+
+```elixir
+def deps do
+  [
+    {:reproject, "~> 1.0"}
+  ]
+end
 ```
-sudo apt-get install libproj-dev libgdal1-dev
+
+Precompiled binaries are provided for common platforms (Linux x86_64/aarch64,
+macOS x86_64/aarch64). `mix deps.get` will download the appropriate binary
+automatically.
+
+### Building from source
+
+To build from source (for development or unsupported platforms):
+
+```bash
+bash scripts/build_libs.sh
+REPROJECT_BUILD_FROM_SOURCE=1 BUNDLED_LIBS_PREFIX=prebuilt mix compile
+mix test
 ```
 
-You may need to build from source. Download proj 4.9.3 [here](https://download.osgeo.org/proj/proj-4.9.3.tar.gz) and `./configure && make && make install`. On ubuntu 20, you may need to add /usr/local/lib to your library path, like `export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib`
-
-
-Then `mix compile` should work and `mix test` should pass.
+`scripts/build_libs.sh` builds static PROJ, GDAL, and SQLite3 libraries — via
+Docker on Linux, or Homebrew + source on macOS.
 
 ## Usage
-Initialize a projection from a proj4 string
+
+Initialize a projection from an EPSG code:
+
+```elixir
+iex> {:ok, prj} = Reproject.create("EPSG:4326")
+```
+
+It is also possible to use the legacy PROJ4 syntax for backwards compatibility.
+However the above format should be preferred.
+
 ```elixir
 iex> {:ok, prj} = Reproject.create("+init=epsg:4326")
 ```
 
-Initialize a projection from a PRJ component of a shapefile
+Initialize a projection from a PRJ component of a shapefile:
+
 ```elixir
 {:ok, prj} = Reproject.create_from_prj("""
   GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433],AUTHORITY["EPSG",4326]]
 """)
 ```
 
-Initialize a projection from a WKT string
+Initialize a projection from a WKT string:
+
 ```elixir
 {:ok, prj} = Reproject.create_from_wkt("""
   GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433],AUTHORITY["EPSG",4326]]
 """)
 ```
 
-Transform a point from source projection to dest projection
+Transform a point from source projection to dest projection:
+
 ```elixir
-iex> {:ok, wgs84} = Reproject.create("+init=epsg:4326")
-iex> {:ok, crs2180} = Reproject.create("+init=epsg:2180")
+iex> {:ok, wgs84} = Reproject.create("EPSG:4326")
+iex> {:ok, crs2180} = Reproject.create("EPSG:2180")
 iex> Reproject.transform(wgs84, crs2180, {21.049804687501, 52.22900390625})
 {:ok, {639951.5695094677, 486751.7840663176}}
 ```
 
-Get the expanded projection definition
+Get the expanded projection definition:
+
 ```elixir
+iex> {:ok, prj} = Reproject.create("EPSG:4326")
 iex> Reproject.expand(prj)
-" +init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0"
+"+proj=longlat +datum=WGS84 +no_defs +type=crs"
 ```

--- a/checksum.exs
+++ b/checksum.exs
@@ -1,0 +1,8 @@
+%{
+  "reproject-nif-2.16-aarch64-linux-gnu-1.0.0-rc.0.tar.gz" => "sha256:221506bfba4340a2a4ec9ceee12e44cf1343f295780ce2e35f35f50f01133575",
+  "reproject-nif-2.16-x86_64-linux-gnu-1.0.0-rc.0.tar.gz" => "sha256:d8316927a6093d72cb017da533d6636fb02dbd311ceb69553e476c653df9d7d7",
+  "reproject-nif-2.17-aarch64-apple-darwin-1.0.0-rc.0.tar.gz" => "sha256:21d8fee5d141c71efa9ce7500295fc06d4d1cbd380bf7ad77f354b35882a5b35",
+  "reproject-nif-2.17-aarch64-linux-gnu-1.0.0-rc.0.tar.gz" => "sha256:8419e25ddd708bb9fd181e129e9ffefb38f9d222df2d99708a340754461258af",
+  "reproject-nif-2.17-x86_64-apple-darwin-1.0.0-rc.0.tar.gz" => "sha256:edd5032db8e8d8c70e1b1d7a6d00b77413152430925ecfd09c8e77440cfe021e",
+  "reproject-nif-2.17-x86_64-linux-gnu-1.0.0-rc.0.tar.gz" => "sha256:bd955b20d00808abcfe8bcb44e496754243bc0b99e984870d99da6ec4e2a62c2",
+}

--- a/lib/reproject.ex
+++ b/lib/reproject.ex
@@ -1,12 +1,19 @@
 defmodule Reproject do
   @on_load {:init, 0}
 
-  app = Mix.Project.config[:app]
-
+  app = Mix.Project.config()[:app]
 
   def init do
-    path = :filename.join(:code.priv_dir(unquote(app)), 'reproject')
-    :ok = :erlang.load_nif(path, 0)
+    priv = :code.priv_dir(unquote(app))
+    proj_data = Path.join(to_string(priv), "proj_data")
+
+    path = :filename.join(priv, ~c"reproject")
+
+    case :erlang.load_nif(path, to_charlist(proj_data)) do
+      :ok -> :ok
+      {:error, {:reload, _}} -> :ok
+      {:error, _} -> :ok
+    end
   end
 
   @doc """
@@ -16,7 +23,7 @@ defmodule Reproject do
     iex> Reproject.expand(prj)
     "+proj=longlat +datum=WGS84 +no_defs +type=crs"
   """
-  def expand(_), do: {:error, :nif_not_loaded}
+  def expand(_), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
     Get a name for the projection
@@ -25,8 +32,7 @@ defmodule Reproject do
     # iex> Reproject.get_projection_name(prj)
     # "WGS 84"
   """
-  def get_projection_name(_), do: {:error, :nif_not_loaded}
-
+  def get_projection_name(_), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
     Create a projection. This returns `{:ok, projection}` where projection
@@ -35,9 +41,7 @@ defmodule Reproject do
     iex> {:ok, _} = Reproject.create("EPSG:4326")
   """
   def create(b) when is_binary(b), do: :binary.bin_to_list(b) |> do_create
-  def do_create(_), do: {:error, :nif_not_loaded}
-
-
+  def do_create(_), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
     Create a projection from a WKT. This returns the same thing as the `create/1` function.
@@ -46,14 +50,15 @@ defmodule Reproject do
 
   """
   def create_from_wkt(wkt) when is_binary(wkt) do
-    wkt_l = wkt
-    |> String.trim
-    |> :binary.bin_to_list
+    wkt_l =
+      wkt
+      |> String.trim()
+      |> :binary.bin_to_list()
 
     do_create_from_wkt(length(wkt_l), wkt_l, 0)
   end
-  def do_create_from_wkt(_, _, _), do: {:error, :nif_not_loaded}
 
+  def do_create_from_wkt(_, _, _), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
     Create a projection from a WKT, like the one in the .prj component
@@ -63,14 +68,13 @@ defmodule Reproject do
 
   """
   def create_from_prj(wkt) when is_binary(wkt) do
-    wkt_l = wkt
-    |> String.trim
-    |> :binary.bin_to_list
+    wkt_l =
+      wkt
+      |> String.trim()
+      |> :binary.bin_to_list()
 
     do_create_from_wkt(length(wkt_l), wkt_l, 1)
   end
-
-
 
   @doc """
     Transform a point from source projection to dest projection
@@ -81,9 +85,9 @@ defmodule Reproject do
     iex> {is_number(x), is_number(y)}
     {true, true}
   """
-  def transform_2d(_, _, _), do: {:error, :nif_not_loaded}
-  def transform_3d(_, _, _), do: {:error, :nif_not_loaded}
+  def transform_2d(_, _, _), do: :erlang.nif_error(:nif_not_loaded)
+  def transform_3d(_, _, _), do: :erlang.nif_error(:nif_not_loaded)
 
-  def transform(src, dst, {_x, _y} = p),     do: transform_2d(src, dst, p)
+  def transform(src, dst, {_x, _y} = p), do: transform_2d(src, dst, p)
   def transform(src, dst, {_x, _y, _z} = p), do: transform_3d(src, dst, p)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,28 @@
 defmodule Reproject.Mixfile do
   use Mix.Project
 
+  @version "1.0.0-rc.0"
+
+  @precompiler_opts (if System.get_env("REPROJECT_BUILD_FROM_SOURCE") do
+                       []
+                     else
+                       [
+                         make_precompiler: {:nif, CCPrecompiler},
+                         make_precompiler_url:
+                           "https://github.com/Tango-Tango/reproject/releases/download/v#{@version}/@{artefact_filename}",
+                         make_precompiler_filename: "reproject",
+                         make_precompiler_priv_paths: ["reproject.*", "proj_data"],
+                         make_precompiler_nif_versions: [
+                           versions: ["2.16", "2.17"],
+                           fallback_version: "2.17"
+                         ]
+                       ]
+                     end)
+
   def project do
     [
       app: :reproject,
-      version: "1.0.0",
+      version: @version,
       elixir: ">= 1.17.0",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -14,12 +32,12 @@ defmodule Reproject.Mixfile do
       package: package(),
       description: description(),
       deps: deps()
-    ]
+    ] ++ @precompiler_opts
   end
 
   defp description do
     """
-      NIFs for repojecting points with proj4. Inspiration from greenelephantlabs/proj4erl.
+      NIFs for reprojecting points with proj4. Inspiration from greenelephantlabs/proj4erl.
     """
   end
 
@@ -33,6 +51,7 @@ defmodule Reproject.Mixfile do
         README.md
         LICENSE
         Makefile
+        checksum.exs
         config
         src
         lib
@@ -46,7 +65,8 @@ defmodule Reproject.Mixfile do
 
   defp deps do
     [
-      {:elixir_make, "~> 0.9.0", runtime: false}
+      {:elixir_make, "~> 0.9", runtime: false},
+      {:cc_precompiler, "~> 0.1", runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "cc_precompiler": {:hex, :cc_precompiler, "0.1.11", "8c844d0b9fb98a3edea067f94f616b3f6b29b959b6b3bf25fee94ffe34364768", [:mix], [{:elixir_make, "~> 0.7", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "3427232caf0835f94680e5bcf082408a70b48ad68a5f5c0b02a3bea9f3a075b9"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.44", "f20830dd6b5c77afe2b063777ddbbff09f9759396500cdbe7523efd58d7a339c", [:mix], [], "hexpm", "4778ac752b4701a5599215f7030989c989ffdc4f6df457c5f36938cc2d2a2750"},
   "elixir_make": {:hex, :elixir_make, "0.9.0", "6484b3cd8c0cee58f09f05ecaf1a140a8c97670671a6a0e7ab4dc326c3109726", [:mix], [], "hexpm", "db23d4fd8b757462ad02f8aa73431a426fe6671c80b200d9710caf3d1dd0ffdb"},
   "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},

--- a/scripts/build_libs.sh
+++ b/scripts/build_libs.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJ_VERSION=${PROJ_VERSION:-9.4.1}
+GDAL_VERSION=${GDAL_VERSION:-3.9.3}
+SQLITE_VERSION=${SQLITE_VERSION:-3470200}
+ROOT=$(git rev-parse --show-toplevel)
+PREBUILT_DIR=${PREBUILT_DIR:-${ROOT}/prebuilt}
+AARCH64_PREBUILT_DIR="${ROOT}/prebuilt-aarch64"
+OS=$(uname -s)
+
+echo "==> Building PROJ ${PROJ_VERSION} and GDAL ${GDAL_VERSION}"
+
+# Build native static libs
+if [ -f "${PREBUILT_DIR}/lib/libgdal.a" ]; then
+  echo "==> Prebuilt libs already exist at ${PREBUILT_DIR}, skipping."
+  echo "    Delete ${PREBUILT_DIR} to force a rebuild."
+else
+  mkdir -p "${PREBUILT_DIR}"
+
+  if [ "$OS" = "Linux" ]; then
+    echo "==> Building inside Docker (debian:bookworm-slim)..."
+    docker buildx build \
+      --progress=plain \
+      --build-arg PROJ_VERSION="${PROJ_VERSION}" \
+      --build-arg GDAL_VERSION="${GDAL_VERSION}" \
+      --build-arg SQLITE_VERSION="${SQLITE_VERSION}" \
+      --output "type=local,dest=${PREBUILT_DIR}" \
+      -f Dockerfile.build \
+      .
+
+  elif [ "$OS" = "Darwin" ]; then
+    echo "==> Installing build dependencies via Homebrew..."
+    brew install cmake ninja
+
+    BUILD_DIR=$(mktemp -d)
+    trap 'rm -rf "$BUILD_DIR"' EXIT
+
+    echo "==> Building SQLite3 ${SQLITE_VERSION}..."
+    curl -fL "https://www.sqlite.org/2024/sqlite-autoconf-${SQLITE_VERSION}.tar.gz" | tar xz -C "$BUILD_DIR"
+    (cd "$BUILD_DIR/sqlite-autoconf-${SQLITE_VERSION}" && \
+      CFLAGS="-fPIC -O2" ./configure --prefix="${PREBUILT_DIR}" --disable-shared --enable-static && \
+      make -j"$(sysctl -n hw.logicalcpu)" && make install)
+    export PATH="${PREBUILT_DIR}/bin:${PATH}"
+
+    echo "==> Building PROJ ${PROJ_VERSION}..."
+    curl -fL "https://download.osgeo.org/proj/proj-${PROJ_VERSION}.tar.gz" | tar xz -C "$BUILD_DIR"
+    cmake -S "$BUILD_DIR/proj-${PROJ_VERSION}" -B "$BUILD_DIR/proj-build" -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX="${PREBUILT_DIR}" \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DBUILD_APPS=OFF \
+      -DENABLE_TIFF=OFF \
+      -DENABLE_CURL=OFF \
+      "-DSQLITE3_INCLUDE_DIR=${PREBUILT_DIR}/include" \
+      "-DSQLITE3_LIBRARY=${PREBUILT_DIR}/lib/libsqlite3.a"
+    cmake --build "$BUILD_DIR/proj-build" --parallel
+    cmake --install "$BUILD_DIR/proj-build"
+
+    echo "==> Building GDAL ${GDAL_VERSION} (minimal OGR build)..."
+    curl -fL "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz" \
+      | tar xz -C "$BUILD_DIR"
+    cmake -S "$BUILD_DIR/gdal-${GDAL_VERSION}" -B "$BUILD_DIR/gdal-build" -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX="${PREBUILT_DIR}" \
+      -DCMAKE_PREFIX_PATH="${PREBUILT_DIR}" \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DBUILD_APPS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DGDAL_USE_CURL=OFF \
+      -DGDAL_USE_EXPAT=OFF \
+      -DGDAL_USE_LIBXML2=OFF \
+      -DGDAL_USE_PNG=OFF \
+      -DGDAL_USE_JPEG=OFF \
+      -DGDAL_USE_TIFF=OFF \
+      -DGDAL_USE_JSONC=OFF \
+      -DGDAL_USE_QHULL=OFF \
+      -DGDAL_USE_OPENJPEG=OFF \
+      -DGDAL_USE_WEBP=OFF \
+      -DGDAL_USE_GEOS=OFF \
+      -DGDAL_OBJECT_LIBRARIES_POSITION_INDEPENDENT_CODE=ON \
+      "-DPROJ_INCLUDE_DIR=${PREBUILT_DIR}/include" \
+      "-DPROJ_LIBRARY=${PREBUILT_DIR}/lib/libproj.a" \
+      "-DSQLITE3_INCLUDE_DIR=${PREBUILT_DIR}/include" \
+      "-DSQLITE3_LIBRARY=${PREBUILT_DIR}/lib/libsqlite3.a"
+    cmake --build "$BUILD_DIR/gdal-build" --parallel
+    cmake --install "$BUILD_DIR/gdal-build"
+
+  else
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+  fi
+
+  echo ""
+  echo "==> Done. Static libs installed to ${PREBUILT_DIR}"
+fi
+
+# Build aarch64 static libs via Docker with QEMU emulation.
+# Skipped in CI — the workflow uses native arm64 runners for aarch64 builds.
+if [ "$OS" = "Linux" ] && [ -z "${CI:-}" ]; then
+  if [ -f "${AARCH64_PREBUILT_DIR}/lib/libgdal.a" ]; then
+    echo "==> aarch64 prebuilt libs already exist at ${AARCH64_PREBUILT_DIR}, skipping."
+    echo "    Delete ${AARCH64_PREBUILT_DIR} to force a rebuild."
+  else
+    echo "==> Building aarch64 static libs via Docker (requires QEMU binfmt)..."
+    docker run --rm --privileged tonistiigi/binfmt --install arm64
+    mkdir -p "${AARCH64_PREBUILT_DIR}"
+    docker buildx build \
+      --platform linux/arm64 \
+      --progress=plain \
+      --build-arg PROJ_VERSION="${PROJ_VERSION}" \
+      --build-arg GDAL_VERSION="${GDAL_VERSION}" \
+      --build-arg SQLITE_VERSION="${SQLITE_VERSION}" \
+      --output "type=local,dest=${AARCH64_PREBUILT_DIR}" \
+      -f Dockerfile.build \
+      .
+  fi
+fi
+
+if [ -n "${CI:-}" ]; then
+  echo "==> Running in CI — skipping local precompile (handled by workflow)."
+  exit 0
+fi
+
+CACHE_DIR="${CACHE_DIR:-${ROOT}/cache}"
+mkdir -p "${CACHE_DIR}"
+
+echo "==> Precompiling NIF tarball (native)..."
+(cd "${ROOT}" && \
+  BUNDLED_LIBS_PREFIX="${PREBUILT_DIR}" \
+  ELIXIR_MAKE_CACHE_DIR="${CACHE_DIR}" \
+  MIX_ENV=prod \
+  mix elixir_make.precompile)
+
+if [ "$OS" = "Linux" ]; then
+  if command -v aarch64-linux-gnu-g++ >/dev/null 2>&1 && [ -f "${AARCH64_PREBUILT_DIR}/lib/libgdal.a" ]; then
+    echo "==> Cross-compiling aarch64-linux-gnu NIF..."
+    (cd "${ROOT}" && \
+      CC=aarch64-linux-gnu-gcc \
+      CXX=aarch64-linux-gnu-g++ \
+      BUNDLED_LIBS_PREFIX="${AARCH64_PREBUILT_DIR}" \
+      ELIXIR_MAKE_CACHE_DIR="${CACHE_DIR}" \
+      CC_PRECOMPILER_CURRENT_TARGET=aarch64-linux-gnu \
+      MIX_ENV=prod \
+      mix elixir_make.precompile)
+  else
+    echo "==> Skipping aarch64 NIF cross-compile."
+    echo "    Ensure aarch64 libs are built and install cross-compiler:"
+    echo "    sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+  fi
+fi
+
+echo ""
+echo "==> Tarball(s) written to ${CACHE_DIR}:"
+ls "${CACHE_DIR}"/*.tar.gz 2>/dev/null || echo "  (none found)"
+echo ""
+echo "==> To test locally:"
+echo "    REPROJECT_BUILD_FROM_SOURCE=1 BUNDLED_LIBS_PREFIX=${PREBUILT_DIR} mix compile"
+echo "    mix test"

--- a/src/reproject.cc
+++ b/src/reproject.cc
@@ -68,8 +68,14 @@ static void cleanup_proj_struct(ErlNifEnv *env, void *cd)
   if(pcd->hsr) CPLFree(pcd->hsr);
 }
 
-static int load(ErlNifEnv* env, void** _priv, ERL_NIF_TERM _info)
+static int load(ErlNifEnv* env, void** _priv, ERL_NIF_TERM load_info)
 {
+  char proj_data_path[4096] = {0};
+  if (enif_get_string(env, load_info, proj_data_path, sizeof(proj_data_path), ERL_NIF_LATIN1) > 0) {
+    const char* paths[] = {proj_data_path};
+    proj_context_set_search_paths(PJ_DEFAULT_CTX, 1, paths);
+  }
+
   ErlNifResourceType *resource_type = enif_open_resource_type(
     env,
     "reproject",
@@ -86,6 +92,7 @@ static int load(ErlNifEnv* env, void** _priv, ERL_NIF_TERM _info)
 
   reproject_atoms.ok = enif_make_atom(env, "ok");
   reproject_atoms.error = enif_make_atom(env, "error");
+  proj_context_use_proj4_init_rules(PJ_DEFAULT_CTX, TRUE);
 
   return 0;
 }


### PR DESCRIPTION
GitHub actions are used to generate shared objects for the NIFs. These are included in a release along with the required sqlite database. This allows the NIF to be easily used without requiring the libraries to be present for the caller.

The NIF shim has been updated to use the correct `:erlang.nif_error(:nif_not_loaded)` return - this ensures compatability with the Elixir type checker.